### PR TITLE
ENH: Upgrade software anaconda=2025.06, and python=3.13

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,8 +1,9 @@
 name: Build Cache [using jupyter-book]
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    # Execute cache weekly at 3am on Monday
+    - cron:  '0 3 * * 1'
+  workflow_dispatch:
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -15,7 +16,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: 3.12
+          python-version: 3.13
           environment-file: environment.yml
           activate-environment: quantecon
       - name: Build HTML

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: 3.12
+          python-version: 3.13
           environment-file: environment.yml
           activate-environment: quantecon
       - name: Install latex dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      # - name: Download "build" folder (cache)
-      #   uses: dawidd6/action-download-artifact@v2
-      #   with:
-      #     workflow: cache.yml
-      #     branch: master
-      #     name: build-cache
-      #     path: _build
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: cache.yml
+          branch: master
+          name: build-cache
+          path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build PDF from LaTeX
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: cache.yml
-          branch: master
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v2
+      #   with:
+      #     workflow: cache.yml
+      #     branch: master
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build PDF from LaTeX
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: Build Project [using jupyter-book]
-on: [push]
+on: 
+  pull_request:
+  workflow_dispatch:
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: '3.12'
+          python-version: 3.13
           environment-file: environment.yml
           activate-environment: quantecon
       - name: Download "build" folder (cache)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: 3.12
+          python-version: 3.13
           environment-file: environment.yml
           activate-environment: quantecon
       - name: Install latex dependencies
@@ -36,13 +36,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      # - name: Download "build" folder (cache)
-      #   uses: dawidd6/action-download-artifact@v2
-      #   with:
-      #     workflow: cache.yml
-      #     branch: main
-      #     name: build-cache
-      #     path: _build
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build PDF from LaTeX
         shell: bash -l {0}

--- a/environment.yml
+++ b/environment.yml
@@ -2,17 +2,16 @@ name: quantecon
 channels:
   - default
 dependencies:
-  - python=3.12
-  - anaconda=2024.10
+  - python=3.13
+  - anaconda=2025.06
   - pip
   - pip:
-    - jupyter-book==1.0.3
-    - quantecon-book-theme==0.7.6
-    - sphinx-tojupyter==0.3.0
+    - jupyter-book==1.0.4post1
+    - quantecon-book-theme==0.8.3
+    - sphinx-tojupyter==0.3.1
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.0.1
-    - ghp-import==2.1.0
-    - sphinxcontrib-youtube
-    - sphinx-proof==0.2.0
-    - quantecon
+    - sphinxcontrib-youtube==1.4.1
+    - sphinx-togglebutton==0.3.2
+
 

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
     - jupyter-book==1.0.4post1
     - quantecon-book-theme==0.8.3
     - sphinx-tojupyter==0.3.1
+    - sphinx-proof==0.2.1
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.0.1
     - sphinxcontrib-youtube==1.4.1


### PR DESCRIPTION
This PR:

- upgrades `anaconda=2025.06`
- python=3.13

This includes upgrades to `jb==1.04post1` and the latest `sphinx-tojupyter`, `quantecon-book-theme` etc. 

## Tasks

- [x] check full execution build
- [x] re-enable the build cache (will re-enable once merged and build cache is updated)
- [x] update all workflows to `python=3.13`